### PR TITLE
Fix video acceleration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "A Linux desktop web app for GeForce NOW",
   "main": "scripts/main.js",
   "scripts": {
-    "start": "electron --enable-accelerated-mjpeg-decode --enable-accelerated-video --ignore-gpu-blacklist --enable-native-gpu-memory-buffers --enable-gpu-rasterization .",
+    "start": "electron .",
     "build": "electron-builder --publish never"
   },
   "build": {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -19,6 +19,7 @@ if (process.argv.includes('--spoof-windows')) {
 console.log('Using user agent: ' + userAgent);
 
 app.commandLine.appendSwitch("enable-features", "VaapiVideoDecoder");
+app.commandLine.appendSwitch("disable-features", "UseChromeOSDirectVideoDecoder");
 
 async function createWindow() {
   const mainWindow = new BrowserWindow({

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -20,6 +20,11 @@ console.log('Using user agent: ' + userAgent);
 
 app.commandLine.appendSwitch("enable-features", "VaapiVideoDecoder");
 app.commandLine.appendSwitch("disable-features", "UseChromeOSDirectVideoDecoder");
+app.commandLine.appendSwitch("enable-accelerated-mjpeg-decode");
+app.commandLine.appendSwitch("enable-accelerated-video");
+app.commandLine.appendSwitch("ignore-gpu-blacklist");
+app.commandLine.appendSwitch("enable-native-gpu-memory-buffers");
+app.commandLine.appendSwitch("enable-gpu-rasterization");
 
 async function createWindow() {
   const mainWindow = new BrowserWindow({


### PR DESCRIPTION
- Added a new switch required for Chromium >98
- Moved switches from package.json to main.js (they were is start script, so that wouldn't be distributed with electron-builder)