### PR TITLE
Removed the deb build for Debian-based distros

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
       "target": [
         "zip",
         "AppImage",
-        "deb",
         "apk",
         "snap"
       ],


### PR DESCRIPTION
Please use the flatpak _(recommended)_ or snap version instead.