### PR TITLE
Fix UA spoofing, add --lang

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,154 +1,183 @@
-const {app, globalShortcut, BrowserWindow } = require('electron');
+const { app, globalShortcut, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 const { DiscordRPC } = require('./rpc.js');
 const { switchFullscreenState } = require('./windowManager.js');
 
-var homePage = 'https://play.geforcenow.com';
+const HOME_PAGE = 'https://play.geforcenow.com?toto=tata';
 
-  var userAgent =
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.101 Safari/537.36'; // Linux
+const DEFAULT_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.101 Safari/537.36';
+const WIN_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36';
+const CHROME_UA = 'Mozilla/5.0 (X11; CrOS x86_64 14909.100.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.83 Safari/537.36';
 
-  if (process.argv.includes('--spoof-chromeos')) {
-    userAgent =
-      'Mozilla/5.0 (X11; CrOS x86_64 14909.100.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.83 Safari/537.36'; // ChromeOS
-    app.commandLine.appendSwitch('disable-features', 'UserAgentClientHint');
-  }
+const DEFAULT_LANG = 'en-GB';
 
-  if (process.argv.includes('--spoof-windows')) {
-    userAgent =
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36'; // Windows
-    app.commandLine.appendSwitch('disable-features', 'UserAgentClientHint');
-  }
+const DEFAULT_PLATFORM = 'Linux X86_64';
+const WIN_PLATFORM = 'Windows';
+const CHROME_PLATFORM = DEFAULT_PLATFORM;
 
-  console.log('Using user agent: ' + userAgent);
-  console.log('Process arguments: ' + process.argv);
+var homePage = HOME_PAGE;
 
-  app.commandLine.appendSwitch('enable-features', 'VaapiVideoDecoder,WaylandWindowDecorations');
-  
-  app.commandLine.appendSwitch(
-    'disable-features',
-    'UseChromeOSDirectVideoDecoder'
-  );
-  app.commandLine.appendSwitch('enable-accelerated-mjpeg-decode');
-  app.commandLine.appendSwitch('enable-accelerated-video');
-  app.commandLine.appendSwitch('ignore-gpu-blacklist');
-  app.commandLine.appendSwitch('enable-native-gpu-memory-buffers');
-  app.commandLine.appendSwitch('enable-gpu-rasterization');
+var userAgent = DEFAULT_UA;
+var platform = DEFAULT_PLATFORM;
+var lang = DEFAULT_LANG;
 
-  async function createWindow() {
-    const mainWindow = new BrowserWindow({
-      fullscreenable: true,
-      webPreferences: {
-        preload: path.join(__dirname, 'preload.js'),
-        contextIsolation: false,
-        userAgent: userAgent,
-      },
-    });
+if (process.argv.includes('--spoof-chromeos')) {
+  userAgent = CHROME_UA;
+  platform = CHROME_PLATFORM;
+}
 
-    if (process.argv.includes('--direct-start')) {
-      mainWindow.loadURL('https://play.geforcenow.com/mall/#/streamer?launchSource=GeForceNOW&cmsId=' + process.argv[process.argv.indexOf('--direct-start') + 1]);
-    } else {
-      mainWindow.loadURL(homePage);
-    }
+if (process.argv.includes('--spoof-windows')) {
+  userAgent = WIN_UA;
+  platform = WIN_PLATFORM;
+}
 
-    /*
-    uncomment this to debug any errors with loading GFN landing page
+if (process.argv.includes('--lang')) {
+  lang = process.argv[process.argv.indexOf('--lang') + 1];
+}
 
-    mainWindow.webContents.on("will-navigate", (event, url) => {
-      console.log("will-navigate", url);
-      event.preventDefault();
-    });
-    */
-  }
+console.log('Using user agent: ' + userAgent);
+console.log('Process arguments: ' + process.argv);
+console.log('Language: ' + lang);
 
-  app.whenReady().then(async () => {
-    createWindow();
+ipcMain.on('getConfigData', function (event, arg) {
+  event.sender.send('configData', {
+    userAgent,
+    platform,
+    lang,
+  });
+});
 
-    DiscordRPC('GeForce NOW');
+app.commandLine.appendSwitch('enable-features', 'VaapiVideoDecoder,WaylandWindowDecorations');
 
-    app.on('activate', async function() {
-      if (BrowserWindow.getAllWindows().length === 0) {
-        createWindow();
-      }
-    });
+app.commandLine.appendSwitch(
+  'disable-features',
+  'UseChromeOSDirectVideoDecoder'
+);
+app.commandLine.appendSwitch('enable-accelerated-mjpeg-decode');
+app.commandLine.appendSwitch('enable-accelerated-video');
+app.commandLine.appendSwitch('ignore-gpu-blacklist');
+app.commandLine.appendSwitch('enable-native-gpu-memory-buffers');
+app.commandLine.appendSwitch('enable-gpu-rasterization');
 
-    globalShortcut.register('Super+F', async () => {
-      switchFullscreenState();
-    });
-
-    globalShortcut.register('F11', async () => {
-      switchFullscreenState();
-    });
-
-    globalShortcut.register('Alt+F4', async () => {
-      app.quit();
-    });
-
-    globalShortcut.register('Alt+Home', async () => {
-      BrowserWindow.getAllWindows()[0].loadURL(homePage);
-    });
-
-    globalShortcut.register('F4', async () => {
-      app.quit();
-    });
-
-    globalShortcut.register('Control+Shift+I', () => {
-      BrowserWindow.getAllWindows()[0].webContents.toggleDevTools();
-    });
-
-    globalShortcut.register('Esc', async () => {
-      var window = BrowserWindow.getAllWindows()[0];
-
-      window.webContents.sendInputEvent({
-        type: 'keyDown',
-        keyCode: 'Esc'
-      });
-      window.webContents.sendInputEvent({
-        type: 'char',
-        keyCode: 'Esc'
-      });
-      window.webContents.sendInputEvent({
-        type: 'keyUp',
-        keyCode: 'Esc'
-      });
-
-      window.webContents.sendInputEvent({
-        type: 'keyDown',
-        keyCode: 'Esc'
-      });
-      window.webContents.sendInputEvent({
-        type: 'char',
-        keyCode: 'Esc'
-      });
-      window.webContents.sendInputEvent({
-        type: 'keyUp',
-        keyCode: 'Esc'
-      });
-    });
+async function createWindow() {
+  const mainWindow = new BrowserWindow({
+    fullscreenable: true,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: false,
+      userAgent,
+    },
   });
 
-  app.on('browser-window-created', async function(e, window) {
-    window.setBackgroundColor('#1A1D1F');
-    window.setMenu(null);
+  ipcMain.handle('getConfig', () => ({
+    userAgent,
+    platform,
+    lang,
+  }));
 
-    window.webContents.setUserAgent(userAgent);
+  if (process.argv.includes('--direct-start')) {
+    homePage = 'https://play.geforcenow.com/mall/#/streamer?launchSource=GeForceNOW&cmsId=' + process.argv[process.argv.indexOf('--direct-start') + 1];
+  }
+  mainWindow.loadURL(homePage, { userAgent });
 
-    window.webContents.on('new-window', (event, url) => {
-      event.preventDefault();
-      BrowserWindow.getAllWindows()[0].loadURL(url);
-    });
+  /*
+  uncomment this to debug any errors with loading GFN landing page
 
-    window.on('page-title-updated', async function(e, title) {
-      DiscordRPC(title);
-    });
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    console.log("will-navigate", url);
+    event.preventDefault();
   });
+  */
+}
 
-  app.on('will-quit', async () => {
-    globalShortcut.unregisterAll();
-  });
+app.whenReady().then(async () => {
+  createWindow();
 
-  app.on('window-all-closed', async function() {
-    if (process.platform !== 'darwin') {
-      app.quit();
+  BrowserWindow.getAllWindows()[0].webContents.openDevTools();
+
+  DiscordRPC('GeForce NOW');
+
+  app.on('activate', async function() {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
     }
   });
+
+  globalShortcut.register('Super+F', async () => {
+    switchFullscreenState();
+  });
+
+  globalShortcut.register('F11', async () => {
+    switchFullscreenState();
+  });
+
+  globalShortcut.register('Alt+F4', async () => {
+    app.quit();
+  });
+
+  globalShortcut.register('Alt+Home', async () => {
+    BrowserWindow.getAllWindows()[0].loadURL(HOME_PAGE);
+  });
+
+  globalShortcut.register('F4', async () => {
+    app.quit();
+  });
+
+  globalShortcut.register('Control+Shift+I', () => {
+    BrowserWindow.getAllWindows()[0].webContents.toggleDevTools();
+  });
+
+  globalShortcut.register('Esc', async () => {
+    var window = BrowserWindow.getAllWindows()[0];
+
+    window.webContents.sendInputEvent({
+      type: 'keyDown',
+      keyCode: 'Esc'
+    });
+    window.webContents.sendInputEvent({
+      type: 'char',
+      keyCode: 'Esc'
+    });
+    window.webContents.sendInputEvent({
+      type: 'keyUp',
+      keyCode: 'Esc'
+    });
+
+    window.webContents.sendInputEvent({
+      type: 'keyDown',
+      keyCode: 'Esc'
+    });
+    window.webContents.sendInputEvent({
+      type: 'char',
+      keyCode: 'Esc'
+    });
+    window.webContents.sendInputEvent({
+      type: 'keyUp',
+      keyCode: 'Esc'
+    });
+  });
+});
+
+app.on('browser-window-created', async function(e, window) {
+  window.setBackgroundColor('#1A1D1F');
+  window.setMenu(null);
+
+  window.webContents.on('new-window', (event, url) => {
+    event.preventDefault();
+    BrowserWindow.getAllWindows()[0].loadURL(url);
+  });
+
+  window.on('page-title-updated', async function(e, title) {
+    DiscordRPC(title);
+  });
+});
+
+app.on('will-quit', async () => {
+  globalShortcut.unregisterAll();
+});
+
+app.on('window-all-closed', async function() {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -1,5 +1,40 @@
 // All of the Node.js APIs are available in the preload process.
 // It has the same sandbox as a Chrome extension.
+const { ipcRenderer } = require('electron');
+
+ipcRenderer.send('getConfigData');
+
+ipcRenderer.on('configData', function (event, config) {
+  const {
+    userAgent,
+    platform,
+    lang,
+  } = config || {};
+
+  console.log(userAgent);
+  console.log(platform);
+  console.log(lang);
+
+  navigator.__defineGetter__('userAgent', function(){
+    return userAgent;
+  });
+
+  navigator.__defineGetter__('language', function(){
+    return lang;
+  });
+
+  navigator.__defineGetter__('languages', function(){
+    return [lang];
+  });
+
+  navigator.__defineGetter__('platform', function(){
+    return platform;
+  });
+
+  navigator.userAgentData.__defineGetter__('platform', function(){
+    return platform;
+  });
+});
 
 window.addEventListener("DOMContentLoaded", () => {
   const replaceText = (selector, text) => {


### PR DESCRIPTION
Hi there,

I have an AZERTY keyboard, and I could not get it to work even with `--spoof-chromeos` or `--spoof-windows`.
Also, every time I start a game it's in English, and I have to manually change its lang to French.
I tried Flatpak, Snap, and from source.

It seems that they don't only rely on the User Agent, but on the navigator properties as well (`navigator.userAgent`, `navigator.platform`, etc.).
So I implemented a way to override those properties, and I also added a way to override language, by adding a `--lang` command line option.

`--lang` and `--spoof-windows` work fine, but I still can't change keyboard mapping with `--spoof-chromeos`, so I guess I'm missing something. I don't have a Chromebook myself so I con't go further. Maybe someone will be able to fix it?