### PR TITLE
fix: missing client hints

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,4 @@
-const {app, globalShortcut, BrowserWindow } = require('electron');
+const {app, globalShortcut, BrowserWindow, session } = require('electron');
 const path = require('path');
 const { DiscordRPC } = require('./rpc.js');
 const { switchFullscreenState } = require('./windowManager.js');
@@ -24,7 +24,7 @@ var homePage = 'https://play.geforcenow.com';
   console.log('Process arguments: ' + process.argv);
 
   app.commandLine.appendSwitch('enable-features', 'VaapiVideoDecoder,WaylandWindowDecorations');
-  
+
   app.commandLine.appendSwitch(
     'disable-features',
     'UseChromeOSDirectVideoDecoder'
@@ -62,6 +62,13 @@ var homePage = 'https://play.geforcenow.com';
   }
 
   app.whenReady().then(async () => {
+    // Add User-Agent Client hints to behave like Windows
+    if(process.argv.includes('--spoof-windows')){
+      session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+        details.requestHeaders['sec-ch-ua-platform'] = 'Windows';
+        callback({ cancel: false, requestHeaders: details.requestHeaders });
+      })
+    }
     createWindow();
 
     DiscordRPC('GeForce NOW');

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -32,4 +32,16 @@ window.addEventListener("DOMContentLoaded", () => {
       return oiginalVoices;
     };
   }, 10_000);
+
+  if(navigator.userAgent.includes("Windows")){
+    Object.defineProperty(navigator,"platform", {
+        get: function () { return "Win32"; },
+        set: function (a) {}
+      })
+
+    Object.defineProperty(navigator,"userAgentData", {
+      get: function () { return null; },
+      set: function (a) {}
+    })
+  }
 })();


### PR DESCRIPTION
Nvidia started using [User-Agent Client hints](https://developer.chrome.com/articles/user-agent-client-hints/) to identify devices, thus making mere user-agent edits not enough (causing #171, #168, #159). 
This should fix it.