### PR TITLE
Removed OS spoofing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geforcenow-electron",
   "appId": "com.github.hmlendea.${name}",
   "productName": "GeForce NOW",
-  "version": "1.13.0",
+  "version": "2.0.0",
   "description": "A Linux desktop web app for GeForce NOW",
   "main": "scripts/main.js",
   "scripts": {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,21 +4,7 @@ const { DiscordRPC } = require('./rpc.js');
 const { switchFullscreenState } = require('./windowManager.js');
 
 var homePage = 'https://play.geforcenow.com';
-
-var userAgent =
-  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.101 Safari/537.36'; // Linux
-
-if (process.argv.includes('--spoof-chromeos')) {
-  userAgent =
-    'Mozilla/5.0 (X11; CrOS x86_64 14909.100.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.83 Safari/537.36'; // ChromeOS
-  app.commandLine.appendSwitch('disable-features', 'UserAgentClientHint');
-}
-
-if (process.argv.includes('--spoof-windows')) {
-  userAgent =
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36'; // Windows
-  app.commandLine.appendSwitch('disable-features', 'UserAgentClientHint');
-}
+var userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.101 Safari/537.36'; // Linux
 
 console.log('Using user agent: ' + userAgent);
 console.log('Process arguments: ' + process.argv);
@@ -67,13 +53,6 @@ async function createWindow() {
 }
 
 app.whenReady().then(async () => {
-  // Add User-Agent Client hints to behave like Windows
-  if (process.argv.includes('--spoof-windows')) {
-    session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-      details.requestHeaders['sec-ch-ua-platform'] = 'Windows';
-      callback({ cancel: false, requestHeaders: details.requestHeaders });
-    })
-  }
   createWindow();
 
   DiscordRPC('GeForce NOW');

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -32,20 +32,4 @@ window.addEventListener("DOMContentLoaded", () => {
       return oiginalVoices;
     };
   }, 10_000);
-
-  if (navigator.userAgent.includes("Windows")) {
-    Object.defineProperty(navigator, "platform", {
-      get: function () { return "Win32"; },
-      set: function (a) { }
-    })
-
-    // If let unchecked it will report the kernel version
-    // as a windows version.
-    // 6.1.2 (linux) < 10.0.19041+ (Windows)
-    // Minimum supported is 8+
-    Object.defineProperty(navigator, "userAgentData", {
-      get: function () { return null; },
-      set: function (a) { }
-    })
-  }
 })();


### PR DESCRIPTION
Spoofing Windows and ChromeOS is removed.

This application is supposed to be only a simple wrapper for the official GFN website, and should not circumvent any limitations put in place by Nvidia, such as locking games to certain operating systems.

While we might disagree with their choice of locking out those games, it is still their service and they may do with it as they wish. Any hacks to work around or change the way GFN is supposed to work should not be part of this repository, and thus, should be removed.

The reasons are as follows:
 - It's Nvidia's wish to have GFN behave the way it does, and, since it's their property. Going against this could endanger this project, as Nvidia could take it down at any time. I'm happy they did not, and that this project can keep on going, but I don't want to push our luck and annoy Nvidia until they don't allow it anymore.
 - This could put users at risk too, as it could infringe GFN's ToS. Users who wish to still apply such hacks can still do it themselves, and forks of this repo can be created by anyone, at any time.
 - These hacks are very high-maintenance. Nvidia continuously improves their detection systems _(which is an obvious proof that they do not want us to work around their limitations)_, rendering them obsolete and broken, resulting in a multitude of bug reports over time _(such as #201, #171, #168, #165, etc...)_ that take a long time until they get addressed.