### PR TITLE
Fixed the `Escape` key not working outside of the application (#241)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "discord-rich-presence": "^0.0.8",
+        "electron-localshortcut": "^3.2.1",
         "find-process": "^1.4.7"
       },
       "devDependencies": {
@@ -1768,6 +1769,22 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/electron-is-accelerator": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz",
+      "integrity": "sha512-fLGSAjXZtdn1sbtZxx52+krefmtNuVwnJCV2gNiVt735/ARUboMl8jnNC9fZEqQdlAv2ZrETfmBUsoQci5evJA=="
+    },
+    "node_modules/electron-localshortcut": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/electron-localshortcut/-/electron-localshortcut-3.2.1.tgz",
+      "integrity": "sha512-DWvhKv36GsdXKnaFFhEiK8kZZA+24/yFLgtTwJJHc7AFgDjNRIBJZ/jq62Y/dWv9E4ypYwrVWN2bVrCYw1uv7Q==",
+      "dependencies": {
+        "debug": "^4.0.1",
+        "electron-is-accelerator": "^0.1.0",
+        "keyboardevent-from-electron-accelerator": "^2.0.0",
+        "keyboardevents-areequal": "^0.2.1"
+      }
+    },
     "node_modules/electron-publish": {
       "version": "24.13.1",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.13.1.tgz",
@@ -2541,6 +2558,16 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/keyboardevent-from-electron-accelerator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-2.0.0.tgz",
+      "integrity": "sha512-iQcmNA0M4ETMNi0kG/q0h/43wZk7rMeKYrXP7sqKIJbHkTU8Koowgzv+ieR/vWJbOwxx5nDC3UnudZ0aLSu4VA=="
+    },
+    "node_modules/keyboardevents-areequal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz",
+      "integrity": "sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw=="
     },
     "node_modules/keyv": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "discord-rich-presence": "^0.0.8",
+    "electron-localshortcut": "^3.2.1",
     "find-process": "^1.4.7"
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,5 @@
-const { app, globalShortcut, BrowserWindow, session } = require('electron');
+const { app, BrowserWindow, session } = require('electron');
+const electronLocalshortcut = require('electron-localshortcut');
 const findProcess = require('find-process');
 const fs = require('fs');
 const path = require('path');
@@ -99,59 +100,59 @@ app.whenReady().then(async () => {
     }
   });
 
-  globalShortcut.register('Super+F', async () => {
+  electronLocalshortcut.register('Super+F', async () => {
     switchFullscreenState();
   });
 
-  globalShortcut.register('F11', async () => {
+  electronLocalshortcut.register('F11', async () => {
     switchFullscreenState();
   });
 
-  globalShortcut.register('Alt+F4', async () => {
+  electronLocalshortcut.register('Alt+F4', async () => {
     app.quit();
   });
 
-  globalShortcut.register('Alt+Home', async () => {
+  electronLocalshortcut.register('Alt+Home', async () => {
     BrowserWindow.getAllWindows()[0].loadURL(homePage);
   });
 
-  globalShortcut.register('F4', async () => {
+  electronLocalshortcut.register('F4', async () => {
     app.quit();
   });
 
-  globalShortcut.register('Control+Shift+I', () => {
+  electronLocalshortcut.register('Control+Shift+I', () => {
     BrowserWindow.getAllWindows()[0].webContents.toggleDevTools();
   });
 
-  globalShortcut.register('Esc', async () => {
-    var window = BrowserWindow.getAllWindows()[0];
-
-    window.webContents.sendInputEvent({
-      type: 'keyDown',
-      keyCode: 'Esc'
-    });
-    window.webContents.sendInputEvent({
-      type: 'char',
-      keyCode: 'Esc'
-    });
-    window.webContents.sendInputEvent({
-      type: 'keyUp',
-      keyCode: 'Esc'
-    });
-
-    window.webContents.sendInputEvent({
-      type: 'keyDown',
-      keyCode: 'Esc'
-    });
-    window.webContents.sendInputEvent({
-      type: 'char',
-      keyCode: 'Esc'
-    });
-    window.webContents.sendInputEvent({
-      type: 'keyUp',
-      keyCode: 'Esc'
-    });
-  });
+  // electronLocalshortcut.register('Esc', async () => {
+  //   var window = BrowserWindow.getAllWindows()[0];
+  //
+  //   window.webContents.sendInputEvent({
+  //     type: 'keyDown',
+  //     keyCode: 'Esc'
+  //   });
+  //   window.webContents.sendInputEvent({
+  //     type: 'char',
+  //     keyCode: 'Esc'
+  //   });
+  //   window.webContents.sendInputEvent({
+  //     type: 'keyUp',
+  //     keyCode: 'Esc'
+  //   });
+  //
+  //   window.webContents.sendInputEvent({
+  //     type: 'keyDown',
+  //     keyCode: 'Esc'
+  //   });
+  //   window.webContents.sendInputEvent({
+  //     type: 'char',
+  //     keyCode: 'Esc'
+  //   });
+  //   window.webContents.sendInputEvent({
+  //     type: 'keyUp',
+  //     keyCode: 'Esc'
+  //   });
+  // });
 });
 
 app.on('browser-window-created', async function (e, window) {
@@ -185,7 +186,7 @@ app.on('child-process-gone', (event, details) => {
 });
 
 app.on('will-quit', async () => {
-  globalShortcut.unregisterAll();
+  electronLocalshortcut.unregisterAll();
 });
 
 app.on('window-all-closed', async function () {


### PR DESCRIPTION
### Fixing [ #241](https://github.com/hmlendea/gfn-electron/issues/241)
but required removing for causing infinite recursion :
```
globalShortcut.register('Esc', async () => {
    var window = BrowserWindow.getAllWindows()[0];

    window.webContents.sendInputEvent({
      type: 'keyDown',
      keyCode: 'Esc'
    });
    window.webContents.sendInputEvent({
      type: 'char',
      keyCode: 'Esc'
    });
    window.webContents.sendInputEvent({
      type: 'keyUp',
      keyCode: 'Esc'
    });

    window.webContents.sendInputEvent({
      type: 'keyDown',
      keyCode: 'Esc'
    });
    window.webContents.sendInputEvent({
      type: 'char',
      keyCode: 'Esc'
    });
    window.webContents.sendInputEvent({
      type: 'keyUp',
      keyCode: 'Esc'
    });
  });
```
I don't understand the purpose of that code, can you explain ??